### PR TITLE
[BL-55] Update AssessmentMetric aggregates on session stop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ replay_pid*
 
 /build/
 /.gradle/
+
+# Superpowers specs and plans (local working artifacts, not for version control)
+/docs/superpowers/

--- a/src/main/java/com/biolab/launchpad/internal/repository/AssessmentMetricRepository.java
+++ b/src/main/java/com/biolab/launchpad/internal/repository/AssessmentMetricRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface AssessmentMetricRepository extends CrudRepository<AssessmentMetric, Integer> {
     List<AssessmentMetric> findAllByAssessmentId(Integer assessmentId);
+    Optional<AssessmentMetric> findByAssessmentIdAndConditionalMetricId(Integer assessmentId, Integer conditionalMetricId);
 }

--- a/src/main/java/com/biolab/launchpad/internal/repository/SessionMetricRepository.java
+++ b/src/main/java/com/biolab/launchpad/internal/repository/SessionMetricRepository.java
@@ -4,9 +4,11 @@ import com.biolab.launchpad.internal.repository.model.SessionMetric;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface SessionMetricRepository extends CrudRepository<SessionMetric, Integer> {
     Optional<SessionMetric> findBySessionIdAndConditionalMetricId(Integer sessionId, Integer conditionalMetricId);
+    List<SessionMetric> findAllBySessionIdIn(List<Integer> sessionIds);
 }

--- a/src/main/java/com/biolab/launchpad/internal/repository/SessionRepository.java
+++ b/src/main/java/com/biolab/launchpad/internal/repository/SessionRepository.java
@@ -4,6 +4,9 @@ import com.biolab.launchpad.internal.repository.model.Session;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository("assessmentSessionRepository")
 public interface SessionRepository extends CrudRepository<Session, Integer> {
+    List<Session> findAllByAssessmentId(Integer assessmentId);
 }

--- a/src/main/java/com/biolab/launchpad/internal/service/SessionWorkflowService.java
+++ b/src/main/java/com/biolab/launchpad/internal/service/SessionWorkflowService.java
@@ -77,7 +77,7 @@ public class SessionWorkflowService {
         session.setStatus("COMPLETE");
         Session saved = sessionRepository.save(session);
 
-        computeAggregates(id);
+        computeAggregates(id, session.getAssessmentId());
 
         eventPublisher.publishEvent(new SessionStoppedEvent(id));
         log.info("Session {} stopped", id);
@@ -85,7 +85,7 @@ public class SessionWorkflowService {
         return sessionMapper.toDto(saved);
     }
 
-    private void computeAggregates(Integer sessionId) {
+    private void computeAggregates(Integer sessionId, Integer assessmentId) {
         List<Rep> reps = repRepository.findAllBySessionId(sessionId);
         if (reps.isEmpty()) return;
 
@@ -119,6 +119,39 @@ public class SessionWorkflowService {
                                     .avgValue(avg)
                                     .build())
                     );
+        });
+
+        updateAssessmentMetrics(sessionId, assessmentId);
+    }
+
+    private void updateAssessmentMetrics(Integer sessionId, Integer assessmentId) {
+        List<Integer> allSessionIds = sessionRepository.findAllByAssessmentId(assessmentId)
+                .stream().map(Session::getId).toList();
+
+        List<SessionMetric> allSessionMetrics = sessionMetricRepository.findAllBySessionIdIn(allSessionIds);
+
+        Map<Integer, List<SessionMetric>> byMetric = allSessionMetrics.stream()
+                .collect(Collectors.groupingBy(SessionMetric::getConditionalMetricId));
+
+        byMetric.forEach((conditionalMetricId, sessionMetrics) -> {
+            double min = sessionMetrics.stream().mapToDouble(SessionMetric::getMinValue).min().orElse(0);
+            double max = sessionMetrics.stream().mapToDouble(SessionMetric::getMaxValue).max().orElse(0);
+            double avg = sessionMetrics.stream().mapToDouble(SessionMetric::getAvgValue).average().orElse(0);
+            double lastValue = sessionMetrics.stream()
+                    .filter(sm -> sm.getSessionId().equals(sessionId))
+                    .findFirst()
+                    .map(SessionMetric::getAvgValue)
+                    .orElse(avg);
+
+            assessmentMetricRepository
+                    .findByAssessmentIdAndConditionalMetricId(assessmentId, conditionalMetricId)
+                    .ifPresent(am -> {
+                        am.setMinValue(min);
+                        am.setMaxValue(max);
+                        am.setAvgValue(avg);
+                        am.setLastValue(lastValue);
+                        assessmentMetricRepository.save(am);
+                    });
         });
     }
 }

--- a/src/test/java/com/biolab/launchpad/internal/web/controller/EntityFactory.java
+++ b/src/test/java/com/biolab/launchpad/internal/web/controller/EntityFactory.java
@@ -36,6 +36,7 @@ public class EntityFactory {
     private final ConditionalMetricRepository        conditionalMetricRepository;
     private final TemplateMetricRepository           templateMetricRepository;
     private final AssessmentMetricRepository         assessmentMetricRepository;
+    private final SessionMetricRepository            sessionMetricRepository;
 
     public Measurement createMeasurement(String name) {
 
@@ -327,6 +328,7 @@ public class EntityFactory {
         templateMetricRepository.deleteAll();
         assessmentMetricRepository.deleteAll();
         repMetricRepository.deleteAll();
+        sessionMetricRepository.deleteAll();
         conditionalMetricRepository.deleteAll();
         conditionRepository.deleteAll();
         repRepository.deleteAll();

--- a/src/test/java/com/biolab/launchpad/internal/web/controller/SessionWorkflowIntegrationTest.java
+++ b/src/test/java/com/biolab/launchpad/internal/web/controller/SessionWorkflowIntegrationTest.java
@@ -3,7 +3,13 @@ package com.biolab.launchpad.internal.web.controller;
 import com.biolab.TestcontainersConfiguration;
 import com.biolab.common.SessionStartedEvent;
 import com.biolab.common.SessionStoppedEvent;
+import com.biolab.launchpad.internal.repository.AssessmentMetricRepository;
+import com.biolab.launchpad.internal.repository.RepMetricRepository;
+import com.biolab.launchpad.internal.repository.RepRepository;
 import com.biolab.launchpad.internal.repository.SessionRepository;
+import com.biolab.launchpad.internal.repository.model.Rep;
+import com.biolab.launchpad.internal.repository.model.RepMetric;
+import com.biolab.launchpad.internal.repository.model.Session;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
@@ -15,6 +21,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.event.ApplicationEvents;
 import org.springframework.test.context.event.RecordApplicationEvents;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
@@ -35,6 +44,9 @@ class SessionWorkflowIntegrationTest {
     @Autowired SessionRepository sessionRepository;
     @Autowired EntityFactory entityFactory;
     @Autowired ApplicationEvents events;
+    @Autowired AssessmentMetricRepository assessmentMetricRepository;
+    @Autowired RepRepository repRepository;
+    @Autowired RepMetricRepository repMetricRepository;
 
     @AfterEach
     void tearDown() {
@@ -174,6 +186,50 @@ class SessionWorkflowIntegrationTest {
                                     .with(httpBasic("biolab", "biolab"))
                     )
                     .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("POST /sessions/{id}/stop aggregates rep metrics into AssessmentMetric")
+        void stopComputesAssessmentMetricAggregates() throws Exception {
+            var cm = entityFactory.createConditionalMetric();
+            var assessment = entityFactory.createAssessment();
+            var am = entityFactory.createAssessmentMetric(assessment.getId(), cm.getId());
+
+            var session = sessionRepository.save(Session.builder()
+                    .assessmentId(assessment.getId())
+                    .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 1)))
+                    .status("ACTIVE")
+                    .build());
+
+            var rep1 = repRepository.save(Rep.builder()
+                    .sessionId(session.getId())
+                    .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 1)))
+                    .build());
+            var rep2 = repRepository.save(Rep.builder()
+                    .sessionId(session.getId())
+                    .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 2)))
+                    .build());
+            repMetricRepository.save(RepMetric.builder()
+                    .repId(rep1.getId())
+                    .conditionalMetricId(cm.getId())
+                    .value(10.0)
+                    .build());
+            repMetricRepository.save(RepMetric.builder()
+                    .repId(rep2.getId())
+                    .conditionalMetricId(cm.getId())
+                    .value(20.0)
+                    .build());
+
+            mvc.perform(post(API + "/" + session.getId() + "/stop")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .with(httpBasic("biolab", "biolab")))
+                    .andExpect(status().isOk());
+
+            var updated = assessmentMetricRepository.findById(am.getId()).orElseThrow();
+            assertEquals(10.0, updated.getMinValue().doubleValue(), 0.001);
+            assertEquals(20.0, updated.getMaxValue().doubleValue(), 0.001);
+            assertEquals(15.0, updated.getAvgValue().doubleValue(), 0.001);
+            assertEquals(15.0, updated.getLastValue().doubleValue(), 0.001);
         }
     }
 }


### PR DESCRIPTION
## Summary
- On session stop, compute assessment-level aggregates (min/max/avg/lastValue) on `AssessmentMetric` by aggregating across all `SessionMetric` records for the assessment
- `lastValue` = avg of the session being stopped; min/max/avg derived from session-level summaries
- Added `findAllByAssessmentId` to `SessionRepository`, `findAllBySessionIdIn` to `SessionMetricRepository`, `findByAssessmentIdAndConditionalMetricId` to `AssessmentMetricRepository`
- Added `docs/superpowers/` to `.gitignore`

## Test plan
- [ ] `SessionWorkflowIntegrationTest` — 8 cases all pass, including new `stopComputesAssessmentMetricAggregates` test verifying min/max/avg/lastValue are set correctly after stop

Notion: https://www.notion.so/35d3a253722781528053e8658e1680e8

🤖 Generated with [Claude Code](https://claude.com/claude-code)