### PR TITLE
[BL-54] Player metrics aggregation API

### DIFF
--- a/src/main/java/com/biolab/launchpad/internal/repository/AssessmentRepository.java
+++ b/src/main/java/com/biolab/launchpad/internal/repository/AssessmentRepository.java
@@ -4,6 +4,9 @@ import com.biolab.launchpad.internal.repository.model.Assessment;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface AssessmentRepository extends CrudRepository<Assessment, Integer> {
+    List<Assessment> findAllByPlayerId(Integer playerId);
 }

--- a/src/main/java/com/biolab/launchpad/internal/repository/model/AssessmentMetric.java
+++ b/src/main/java/com/biolab/launchpad/internal/repository/model/AssessmentMetric.java
@@ -27,7 +27,5 @@ public class AssessmentMetric extends ID {
     private Number maxValue;
     @Column("avg_value")
     private Number avgValue;
-    @Column("last_value")
-    private Number lastValue;
     private String description;
 }

--- a/src/main/java/com/biolab/launchpad/internal/service/PlayerMetricsService.java
+++ b/src/main/java/com/biolab/launchpad/internal/service/PlayerMetricsService.java
@@ -1,0 +1,142 @@
+package com.biolab.launchpad.internal.service;
+
+import com.biolab.launchpad.internal.repository.*;
+import com.biolab.launchpad.internal.repository.model.*;
+import com.biolab.launchpad.internal.security.exceptions.NotFoundByException;
+import com.biolab.launchpad.internal.web.dto.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PlayerMetricsService {
+
+    private final PlayerRepository playerRepository;
+    private final AssessmentRepository assessmentRepository;
+    private final AssessmentMetricRepository assessmentMetricRepository;
+    private final ConditionalMetricRepository conditionalMetricRepository;
+    private final MetricRepository metricRepository;
+
+    public PlayerMetricsDto getMetrics(Integer playerId) {
+        playerRepository.findById(playerId)
+                .orElseThrow(() -> new NotFoundByException("Player not found by id: %d", playerId));
+
+        List<Assessment> assessments = assessmentRepository.findAllByPlayerId(playerId);
+        if (assessments.isEmpty()) {
+            return PlayerMetricsDto.builder().overall(List.of()).assessments(List.of()).build();
+        }
+
+        List<Assessment> sorted = assessments.stream()
+                .sorted(Comparator.comparingInt(Assessment::getId))
+                .toList();
+
+        Map<Integer, List<AssessmentMetric>> amsByAssessmentId = new LinkedHashMap<>();
+        for (Assessment a : sorted) {
+            amsByAssessmentId.put(a.getId(), assessmentMetricRepository.findAllByAssessmentId(a.getId()));
+        }
+
+        List<AssessmentMetric> allAms = amsByAssessmentId.values().stream()
+                .flatMap(Collection::stream)
+                .toList();
+
+        Set<Integer> cmIds = allAms.stream()
+                .map(AssessmentMetric::getConditionalMetricId)
+                .collect(Collectors.toSet());
+        Map<Integer, ConditionalMetric> cmById = new HashMap<>();
+        conditionalMetricRepository.findAllById(cmIds).forEach(cm -> cmById.put(cm.getId(), cm));
+
+        Set<Integer> metricIds = cmById.values().stream()
+                .map(ConditionalMetric::getMetricId)
+                .collect(Collectors.toSet());
+        Map<Integer, Metric> metricById = new HashMap<>();
+        metricRepository.findAllById(metricIds).forEach(m -> metricById.put(m.getId(), m));
+
+        List<AssessmentMetricsDto> assessmentDtos = sorted.stream()
+                .map(assessment -> {
+                    List<MetricAggregateDto> metrics = amsByAssessmentId.get(assessment.getId()).stream()
+                            .sorted(Comparator.comparingInt(AssessmentMetric::getConditionalMetricId))
+                            .map(am -> toMetricAggregateDto(am, cmById, metricById))
+                            .toList();
+                    return AssessmentMetricsDto.builder()
+                            .assessmentId(assessment.getId())
+                            .sport(assessment.getSport())
+                            .metrics(metrics)
+                            .build();
+                })
+                .toList();
+
+        List<MetricAggregateDto> overall = computeOverall(allAms, cmById, metricById);
+
+        return PlayerMetricsDto.builder()
+                .overall(overall)
+                .assessments(assessmentDtos)
+                .build();
+    }
+
+    private MetricAggregateDto toMetricAggregateDto(AssessmentMetric am,
+                                                     Map<Integer, ConditionalMetric> cmById,
+                                                     Map<Integer, Metric> metricById) {
+        ConditionalMetric cm = cmById.get(am.getConditionalMetricId());
+        Metric metric = cm != null ? metricById.get(cm.getMetricId()) : null;
+        boolean negated = metric != null && metric.isNegate();
+        return MetricAggregateDto.builder()
+                .conditionalMetricId(am.getConditionalMetricId())
+                .name(cm != null ? cm.getName() : null)
+                .negated(negated)
+                .minValue(am.getMinValue() != null ? am.getMinValue().doubleValue() : null)
+                .maxValue(am.getMaxValue() != null ? am.getMaxValue().doubleValue() : null)
+                .avgValue(am.getAvgValue() != null ? am.getAvgValue().doubleValue() : null)
+                .build();
+    }
+
+    private List<MetricAggregateDto> computeOverall(List<AssessmentMetric> allAms,
+                                                      Map<Integer, ConditionalMetric> cmById,
+                                                      Map<Integer, Metric> metricById) {
+        Map<Integer, List<AssessmentMetric>> byCmId = allAms.stream()
+                .collect(Collectors.groupingBy(AssessmentMetric::getConditionalMetricId));
+
+        return byCmId.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> {
+                    int cmId = entry.getKey();
+                    List<AssessmentMetric> ams = entry.getValue();
+                    ConditionalMetric cm = cmById.get(cmId);
+                    Metric metric = cm != null ? metricById.get(cm.getMetricId()) : null;
+                    boolean negated = metric != null && metric.isNegate();
+
+                    List<Double> minValues = ams.stream()
+                            .filter(am -> am.getMinValue() != null)
+                            .map(am -> am.getMinValue().doubleValue())
+                            .toList();
+                    List<Double> maxValues = ams.stream()
+                            .filter(am -> am.getMaxValue() != null)
+                            .map(am -> am.getMaxValue().doubleValue())
+                            .toList();
+                    List<Double> avgValues = ams.stream()
+                            .filter(am -> am.getAvgValue() != null)
+                            .map(am -> am.getAvgValue().doubleValue())
+                            .toList();
+
+                    OptionalDouble minOpt = negated
+                            ? minValues.stream().mapToDouble(Double::doubleValue).max()
+                            : minValues.stream().mapToDouble(Double::doubleValue).min();
+                    OptionalDouble maxOpt = negated
+                            ? maxValues.stream().mapToDouble(Double::doubleValue).min()
+                            : maxValues.stream().mapToDouble(Double::doubleValue).max();
+                    OptionalDouble avgOpt = avgValues.stream().mapToDouble(Double::doubleValue).average();
+
+                    return MetricAggregateDto.builder()
+                            .conditionalMetricId(cmId)
+                            .name(cm != null ? cm.getName() : null)
+                            .negated(negated)
+                            .minValue(minOpt.isPresent() ? minOpt.getAsDouble() : null)
+                            .maxValue(maxOpt.isPresent() ? maxOpt.getAsDouble() : null)
+                            .avgValue(avgOpt.isPresent() ? avgOpt.getAsDouble() : null)
+                            .build();
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/biolab/launchpad/internal/service/SessionWorkflowService.java
+++ b/src/main/java/com/biolab/launchpad/internal/service/SessionWorkflowService.java
@@ -137,11 +137,6 @@ public class SessionWorkflowService {
             double min = sessionMetrics.stream().mapToDouble(SessionMetric::getMinValue).min().orElse(0);
             double max = sessionMetrics.stream().mapToDouble(SessionMetric::getMaxValue).max().orElse(0);
             double avg = sessionMetrics.stream().mapToDouble(SessionMetric::getAvgValue).average().orElse(0);
-            double lastValue = sessionMetrics.stream()
-                    .filter(sm -> sm.getSessionId().equals(sessionId))
-                    .findFirst()
-                    .map(SessionMetric::getAvgValue)
-                    .orElse(avg);
 
             assessmentMetricRepository
                     .findByAssessmentIdAndConditionalMetricId(assessmentId, conditionalMetricId)
@@ -149,7 +144,6 @@ public class SessionWorkflowService {
                         am.setMinValue(min);
                         am.setMaxValue(max);
                         am.setAvgValue(avg);
-                        am.setLastValue(lastValue);
                         assessmentMetricRepository.save(am);
                     });
         });

--- a/src/main/java/com/biolab/launchpad/internal/service/SessionWorkflowService.java
+++ b/src/main/java/com/biolab/launchpad/internal/service/SessionWorkflowService.java
@@ -14,8 +14,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.biolab.launchpad.internal.web.mapper.SessionMapper.sessionMapper;
@@ -31,6 +30,8 @@ public class SessionWorkflowService {
     private final RepRepository repRepository;
     private final RepMetricRepository repMetricRepository;
     private final SessionMetricRepository sessionMetricRepository;
+    private final ConditionalMetricRepository conditionalMetricRepository;
+    private final MetricRepository metricRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
@@ -77,7 +78,8 @@ public class SessionWorkflowService {
         session.setStatus("COMPLETE");
         Session saved = sessionRepository.save(session);
 
-        computeAggregates(id, session.getAssessmentId());
+        Map<Integer, Boolean> negateByConditionalMetricId = buildNegateMap(session.getAssessmentId());
+        computeAggregates(id, session.getAssessmentId(), negateByConditionalMetricId);
 
         eventPublisher.publishEvent(new SessionStoppedEvent(id));
         log.info("Session {} stopped", id);
@@ -85,7 +87,29 @@ public class SessionWorkflowService {
         return sessionMapper.toDto(saved);
     }
 
-    private void computeAggregates(Integer sessionId, Integer assessmentId) {
+    private Map<Integer, Boolean> buildNegateMap(Integer assessmentId) {
+        List<AssessmentMetric> assessmentMetrics = assessmentMetricRepository.findAllByAssessmentId(assessmentId);
+
+        List<ConditionalMetric> conditionalMetrics = new ArrayList<>();
+        conditionalMetricRepository.findAllById(
+                assessmentMetrics.stream().map(AssessmentMetric::getConditionalMetricId).toList()
+        ).forEach(conditionalMetrics::add);
+
+        Map<Integer, Integer> metricIdByCmId = conditionalMetrics.stream()
+                .collect(Collectors.toMap(ConditionalMetric::getId, ConditionalMetric::getMetricId));
+
+        Map<Integer, Boolean> negateByMetricId = new HashMap<>();
+        metricRepository.findAllById(metricIdByCmId.values())
+                .forEach(m -> negateByMetricId.put(m.getId(), m.isNegate()));
+
+        return metricIdByCmId.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> negateByMetricId.getOrDefault(e.getValue(), false)));
+    }
+
+    private void computeAggregates(Integer sessionId, Integer assessmentId,
+                                   Map<Integer, Boolean> negateByConditionalMetricId) {
         List<Rep> reps = repRepository.findAllBySessionId(sessionId);
         if (reps.isEmpty()) return;
 
@@ -98,9 +122,12 @@ public class SessionWorkflowService {
                         Collectors.mapping(RepMetric::getValue, Collectors.toList())));
 
         byMetric.forEach((conditionalMetricId, values) -> {
-            double min = values.stream().mapToDouble(Number::doubleValue).min().orElse(0);
-            double max = values.stream().mapToDouble(Number::doubleValue).max().orElse(0);
-            double avg = values.stream().mapToDouble(Number::doubleValue).average().orElse(0);
+            boolean negated = negateByConditionalMetricId.getOrDefault(conditionalMetricId, false);
+            double rawMin = values.stream().mapToDouble(Number::doubleValue).min().orElse(0);
+            double rawMax = values.stream().mapToDouble(Number::doubleValue).max().orElse(0);
+            double avg    = values.stream().mapToDouble(Number::doubleValue).average().orElse(0);
+            double min = negated ? rawMax : rawMin;
+            double max = negated ? rawMin : rawMax;
 
             sessionMetricRepository
                     .findBySessionIdAndConditionalMetricId(sessionId, conditionalMetricId)
@@ -121,10 +148,11 @@ public class SessionWorkflowService {
                     );
         });
 
-        updateAssessmentMetrics(sessionId, assessmentId);
+        updateAssessmentMetrics(assessmentId, negateByConditionalMetricId);
     }
 
-    private void updateAssessmentMetrics(Integer sessionId, Integer assessmentId) {
+    private void updateAssessmentMetrics(Integer assessmentId,
+                                         Map<Integer, Boolean> negateByConditionalMetricId) {
         List<Integer> allSessionIds = sessionRepository.findAllByAssessmentId(assessmentId)
                 .stream().map(Session::getId).toList();
 
@@ -134,8 +162,13 @@ public class SessionWorkflowService {
                 .collect(Collectors.groupingBy(SessionMetric::getConditionalMetricId));
 
         byMetric.forEach((conditionalMetricId, sessionMetrics) -> {
-            double min = sessionMetrics.stream().mapToDouble(SessionMetric::getMinValue).min().orElse(0);
-            double max = sessionMetrics.stream().mapToDouble(SessionMetric::getMaxValue).max().orElse(0);
+            boolean negated = negateByConditionalMetricId.getOrDefault(conditionalMetricId, false);
+            double min = negated
+                    ? sessionMetrics.stream().mapToDouble(SessionMetric::getMinValue).max().orElse(0)
+                    : sessionMetrics.stream().mapToDouble(SessionMetric::getMinValue).min().orElse(0);
+            double max = negated
+                    ? sessionMetrics.stream().mapToDouble(SessionMetric::getMaxValue).min().orElse(0)
+                    : sessionMetrics.stream().mapToDouble(SessionMetric::getMaxValue).max().orElse(0);
             double avg = sessionMetrics.stream().mapToDouble(SessionMetric::getAvgValue).average().orElse(0);
 
             assessmentMetricRepository

--- a/src/main/java/com/biolab/launchpad/internal/web/controller/PlayerMetricsController.java
+++ b/src/main/java/com/biolab/launchpad/internal/web/controller/PlayerMetricsController.java
@@ -1,0 +1,19 @@
+package com.biolab.launchpad.internal.web.controller;
+
+import com.biolab.launchpad.internal.service.PlayerMetricsService;
+import com.biolab.launchpad.internal.web.dto.PlayerMetricsDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/players/{id}/metrics")
+public class PlayerMetricsController {
+
+    private final PlayerMetricsService playerMetricsService;
+
+    @GetMapping
+    public PlayerMetricsDto getMetrics(@PathVariable Integer id) {
+        return playerMetricsService.getMetrics(id);
+    }
+}

--- a/src/main/java/com/biolab/launchpad/internal/web/dto/AssessmentMetricDto.java
+++ b/src/main/java/com/biolab/launchpad/internal/web/dto/AssessmentMetricDto.java
@@ -15,6 +15,5 @@ public record AssessmentMetricDto(
         Number minValue,
         Number maxValue,
         Number avgValue,
-        Number lastValue,
         String description
 ){}

--- a/src/main/java/com/biolab/launchpad/internal/web/dto/AssessmentMetricsDto.java
+++ b/src/main/java/com/biolab/launchpad/internal/web/dto/AssessmentMetricsDto.java
@@ -1,0 +1,11 @@
+package com.biolab.launchpad.internal.web.dto;
+
+import lombok.Builder;
+import java.util.List;
+
+@Builder
+public record AssessmentMetricsDto(
+        Integer assessmentId,
+        String sport,
+        List<MetricAggregateDto> metrics
+) {}

--- a/src/main/java/com/biolab/launchpad/internal/web/dto/MetricAggregateDto.java
+++ b/src/main/java/com/biolab/launchpad/internal/web/dto/MetricAggregateDto.java
@@ -1,0 +1,13 @@
+package com.biolab.launchpad.internal.web.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MetricAggregateDto(
+        Integer conditionalMetricId,
+        String name,
+        Boolean negated,
+        Double minValue,
+        Double maxValue,
+        Double avgValue
+) {}

--- a/src/main/java/com/biolab/launchpad/internal/web/dto/PlayerMetricsDto.java
+++ b/src/main/java/com/biolab/launchpad/internal/web/dto/PlayerMetricsDto.java
@@ -1,0 +1,10 @@
+package com.biolab.launchpad.internal.web.dto;
+
+import lombok.Builder;
+import java.util.List;
+
+@Builder
+public record PlayerMetricsDto(
+        List<MetricAggregateDto> overall,
+        List<AssessmentMetricsDto> assessments
+) {}

--- a/src/main/resources/db/changelog/biolab.changelog.yml
+++ b/src/main/resources/db/changelog/biolab.changelog.yml
@@ -9,4 +9,6 @@ databaseChangeLog:
       file: db/changelog/changeset/1_bl_43.yml
   - include:
       file: db/changelog/changeset/1_bl_55.yml
+  - include:
+      file: db/changelog/changeset/1_bl_54.yml
 

--- a/src/main/resources/db/changelog/changeset/1_bl_54.yml
+++ b/src/main/resources/db/changelog/changeset/1_bl_54.yml
@@ -1,0 +1,8 @@
+databaseChangeLog:
+  - changeSet:
+      id: bl-54-drop-last-value-from-assessment-metric
+      author: roman
+      changes:
+        - dropColumn:
+            tableName: assessment_metric
+            columnName: last_value

--- a/src/main/resources/db/scripts/seed-data.sql
+++ b/src/main/resources/db/scripts/seed-data.sql
@@ -129,15 +129,14 @@ WHERE i.name = 'Blast Motion'
   AND cm.condition_id = (SELECT id FROM condition WHERE name = 'Hitting from T');
 
 -- assessment_metric (→ assessment, conditional_metric, data_source)
-INSERT INTO assessment_metric (assessment_id, conditional_metric_id, data_source_id, min_value, max_value, avg_value, last_value)
+INSERT INTO assessment_metric (assessment_id, conditional_metric_id, data_source_id, min_value, max_value, avg_value)
 SELECT
     a.id,
     cm.id,
     ds.id,
     CASE cm.name WHEN 'Bat Speed' THEN 58 WHEN 'Attack Angle' THEN 8  WHEN 'Time to Impact' THEN 145 END,
     CASE cm.name WHEN 'Bat Speed' THEN 75 WHEN 'Attack Angle' THEN 22 WHEN 'Time to Impact' THEN 195 END,
-    CASE cm.name WHEN 'Bat Speed' THEN 67 WHEN 'Attack Angle' THEN 15 WHEN 'Time to Impact' THEN 170 END,
-    CASE cm.name WHEN 'Bat Speed' THEN 70 WHEN 'Attack Angle' THEN 16 WHEN 'Time to Impact' THEN 165 END
+    CASE cm.name WHEN 'Bat Speed' THEN 67 WHEN 'Attack Angle' THEN 15 WHEN 'Time to Impact' THEN 170 END
 FROM assessment a
 CROSS JOIN conditional_metric cm
 JOIN metric m ON m.id = cm.metric_id

--- a/src/test/java/com/biolab/launchpad/internal/web/controller/AssessmentMetricControllerIntegrationTest.java
+++ b/src/test/java/com/biolab/launchpad/internal/web/controller/AssessmentMetricControllerIntegrationTest.java
@@ -29,17 +29,10 @@ class AssessmentMetricControllerIntegrationTest {
 
     private static final String API = "/api/v1/assessmentMetrics";
 
-    @Autowired
-    private MockMvc mvc;
-
-    @Autowired
-    ObjectMapper objectMapper;
-
-    @Autowired
-    AssessmentMetricRepository assessmentMetricRepository;
-
-    @Autowired
-    EntityFactory factory;
+    @Autowired private MockMvc mvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired AssessmentMetricRepository assessmentMetricRepository;
+    @Autowired EntityFactory factory;
 
     Assessment        assessment;
     ConditionalMetric conditionalMetric;
@@ -64,88 +57,66 @@ class AssessmentMetricControllerIntegrationTest {
         @Test
         @DisplayName("POST /assessmentMetrics -> creates and returns the new AssessmentMetric")
         void create() throws Exception {
+            String request = """
+                {
+                    "assessmentId"        : %d,
+                    "conditionalMetricId" : %d,
+                    "dataSourceId"        : %d,
+                    "minValue"            : 1,
+                    "maxValue"            : 2,
+                    "avgValue"            : 3
+                }
+            """.formatted(assessment.getId(), conditionalMetric.getId(), dataSource.getId());
 
-            String request =
-                            """
-                                {
-                                    "assessmentId"        : %d,
-                                    "conditionalMetricId" : %d,
-                                    "dataSourceId"        : %d,
-                                    "minValue"            : 1,
-                                    "maxValue"            : 2,
-                                    "avgValue"            : 3,
-                                    "lastValue"           : 4
-                                }
-                            """.formatted(assessment.getId(), conditionalMetric.getId(), dataSource.getId());
-
-            String jsonResponse = mvc.perform(
-                            post(API)
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(request)
-                                    .with(httpBasic("biolab", "biolab"))
-                    )
-                    .andExpect(status().isOk())
-                    .andReturn().getResponse().getContentAsString();
-
+            String jsonResponse = mvc.perform(post(API)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(request)
+                    .with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
 
             JsonNode responseNode = objectMapper.readTree(jsonResponse);
-
             int id = responseNode.get("id").asInt();
             assertThat(id).isPositive();
 
-            String expectedResponse =
-                                    """
-                                      {
-                                        "id"                  : %d,
-                                        "assessmentId"        : %d,
-                                        "conditionalMetricId" : %d,
-                                        "dataSourceId"        : %d,
-                                        "minValue"            : 1,
-                                        "maxValue"            : 2,
-                                        "avgValue"            : 3,
-                                        "lastValue"           : 4,
-                                        "description"         : null
-                                      }
-                                    """.formatted(id, assessment.getId(), conditionalMetric.getId(), dataSource.getId());
+            String expectedResponse = """
+                {
+                    "id"                  : %d,
+                    "assessmentId"        : %d,
+                    "conditionalMetricId" : %d,
+                    "dataSourceId"        : %d,
+                    "minValue"            : 1,
+                    "maxValue"            : 2,
+                    "avgValue"            : 3,
+                    "description"         : null
+                }
+            """.formatted(id, assessment.getId(), conditionalMetric.getId(), dataSource.getId());
 
-            JsonNode expectedResponseNode = objectMapper.readTree(expectedResponse);
-
-            assertEquals(expectedResponseNode, responseNode);
+            assertEquals(objectMapper.readTree(expectedResponse), responseNode);
         }
 
         @Test
         @DisplayName("POST /assessmentMetrics with validation error -> returns 422")
         void createValidationError() throws Exception {
-            String request =
-                            """
-                                {
-                                    "description" : ""
-                                }
-                            """;
+            String request = """
+                { "description" : "" }
+            """;
 
-            String jsonResponse = mvc.perform(
-                            post(API)
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(request)
-                                    .with(httpBasic("biolab", "biolab"))
-                    )
-                    .andExpect(status().isBadRequest())
-                    .andReturn().getResponse().getContentAsString();
+            String jsonResponse = mvc.perform(post(API)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(request)
+                    .with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
 
+            String expectedResponse = """
+                {
+                    "status"  : 422,
+                    "message" : "Validation failed: assessmentId: AssesmentMetric assessmentId cannot be null, and conditionalMetricId: AssesmentMetric conditionalMetricId cannot be null, and dataSourceId: AssesmentMetric dataSourceId cannot be null"
+                }
+            """;
 
-            JsonNode responseNode = objectMapper.readTree(jsonResponse);
-
-            String expectedResponse =
-                    """
-                            {
-                                "status"  : 422,
-                                "message" : "Validation failed: assessmentId: AssesmentMetric assessmentId cannot be null, and conditionalMetricId: AssesmentMetric conditionalMetricId cannot be null, and dataSourceId: AssesmentMetric dataSourceId cannot be null"
-                            }
-                            """;
-
-            JsonNode expectedResponseNode = objectMapper.readTree(expectedResponse);
-
-            assertEquals(expectedResponseNode, responseNode);
+            assertEquals(objectMapper.readTree(expectedResponse), objectMapper.readTree(jsonResponse));
         }
     }
 
@@ -156,132 +127,69 @@ class AssessmentMetricControllerIntegrationTest {
         @Test
         @DisplayName("GET /assessmentMetrics -> returns all assessmentMetrics")
         void getAll() throws Exception {
+            AssessmentMetric am1 = assessmentMetricRepository.save(AssessmentMetric.builder()
+                .assessmentId(assessment.getId()).conditionalMetricId(conditionalMetric.getId())
+                .dataSourceId(dataSource.getId()).minValue(1).maxValue(2).avgValue(3).build());
 
-            AssessmentMetric assessmentMetric1 = assessmentMetricRepository.save(AssessmentMetric.builder()
-                    .assessmentId(assessment.getId())
-                    .conditionalMetricId(conditionalMetric.getId())
-                    .dataSourceId(dataSource.getId())
-                    .minValue(1)
-                    .maxValue(2)
-                    .avgValue(3)
-                    .lastValue(4)
-                    .build());
+            AssessmentMetric am2 = assessmentMetricRepository.save(AssessmentMetric.builder()
+                .assessmentId(assessment.getId()).conditionalMetricId(conditionalMetric.getId())
+                .dataSourceId(dataSource.getId()).minValue(5).maxValue(6).avgValue(7).build());
 
-            AssessmentMetric assessmentMetric2 = assessmentMetricRepository.save(AssessmentMetric.builder()
-                    .assessmentId(assessment.getId())
-                    .conditionalMetricId(conditionalMetric.getId())
-                    .dataSourceId(dataSource.getId())
-                    .minValue(5)
-                    .maxValue(6)
-                    .avgValue(7)
-                    .lastValue(8)
-                    .build());
-
-            String jsonResponse = mvc.perform(
-                            get(API)
-                                    .with(httpBasic("biolab", "biolab"))
-                    )
-                    .andExpect(status().isOk())
-                    .andReturn().getResponse().getContentAsString();
+            String jsonResponse = mvc.perform(get(API).with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
 
             String expectedResponse = """
                 [
                     {
-                        "id"                  : %d,
-                        "assessmentId"        : %d,
-                        "conditionalMetricId" : %d,
-                        "dataSourceId"        : %d,
-                        "minValue"            : 1,
-                        "maxValue"            : 2,
-                        "avgValue"            : 3,
-                        "lastValue"           : 4,
-                        "description"         : null
+                        "id": %d, "assessmentId": %d, "conditionalMetricId": %d, "dataSourceId": %d,
+                        "minValue": 1, "maxValue": 2, "avgValue": 3, "description": null
                     },
                     {
-                        "id"                  : %d,
-                        "assessmentId"        : %d,
-                        "conditionalMetricId" : %d,
-                        "dataSourceId"        : %d,
-                        "minValue"            : 5,
-                        "maxValue"            : 6,
-                        "avgValue"            : 7,
-                        "lastValue"           : 8,
-                        "description"         : null
+                        "id": %d, "assessmentId": %d, "conditionalMetricId": %d, "dataSourceId": %d,
+                        "minValue": 5, "maxValue": 6, "avgValue": 7, "description": null
                     }
                 ]
-                """.formatted(assessmentMetric1.getId(), assessment.getId(), conditionalMetric.getId(), dataSource.getId(),
-                              assessmentMetric2.getId(), assessment.getId(), conditionalMetric.getId(), dataSource.getId());
+            """.formatted(am1.getId(), assessment.getId(), conditionalMetric.getId(), dataSource.getId(),
+                          am2.getId(), assessment.getId(), conditionalMetric.getId(), dataSource.getId());
 
-            JsonNode expectedNode = objectMapper.readTree(expectedResponse);
-            JsonNode actualNode   = objectMapper.readTree(jsonResponse);
-
-            assertEquals(expectedNode, actualNode);
+            assertEquals(objectMapper.readTree(expectedResponse), objectMapper.readTree(jsonResponse));
         }
 
         @Test
         @DisplayName("GET /assessmentMetrics/{id} -> returns assessmentMetric by ID")
         void getById() throws Exception {
+            AssessmentMetric am = assessmentMetricRepository.save(AssessmentMetric.builder()
+                .assessmentId(assessment.getId()).conditionalMetricId(conditionalMetric.getId())
+                .dataSourceId(dataSource.getId()).minValue(1).maxValue(2).avgValue(3).build());
 
-            AssessmentMetric assessmentMetric = assessmentMetricRepository.save(AssessmentMetric.builder()
-                    .assessmentId(assessment.getId())
-                    .conditionalMetricId(conditionalMetric.getId())
-                    .dataSourceId(dataSource.getId())
-                    .minValue(1)
-                    .maxValue(2)
-                    .avgValue(3)
-                    .lastValue(4)
-                    .build());
-
-            String jsonResponse = mvc.perform(
-                            get(API + "/" + assessmentMetric.getId())
-                                    .with(httpBasic("biolab", "biolab"))
-                    )
-                    .andExpect(status().isOk())
-                    .andReturn().getResponse().getContentAsString();
+            String jsonResponse = mvc.perform(get(API + "/" + am.getId()).with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
 
             String expectedResponse = """
-                                     {
-                                        "id"                  : %d,
-                                        "assessmentId"        : %d,
-                                        "conditionalMetricId" : %d,
-                                        "dataSourceId"        : %d,
-                                        "minValue"            : 1,
-                                        "maxValue"            : 2,
-                                        "avgValue"            : 3,
-                                        "lastValue"           : 4,
-                                        "description"         : null
-                                     }
-                                    """.formatted(assessmentMetric.getId(), assessment.getId(), conditionalMetric.getId(), dataSource.getId());
+                {
+                    "id": %d, "assessmentId": %d, "conditionalMetricId": %d, "dataSourceId": %d,
+                    "minValue": 1, "maxValue": 2, "avgValue": 3, "description": null
+                }
+            """.formatted(am.getId(), assessment.getId(), conditionalMetric.getId(), dataSource.getId());
 
-            JsonNode expectedNode = objectMapper.readTree(expectedResponse);
-            JsonNode actualNode   = objectMapper.readTree(jsonResponse);
-
-            assertEquals(expectedNode, actualNode);
+            assertEquals(objectMapper.readTree(expectedResponse), objectMapper.readTree(jsonResponse));
         }
 
         @Test
         @DisplayName("GET /assessmentMetrics/{id} with unknown ID -> returns 404")
         void getByIdValidationError() throws Exception {
-            String jsonResponse = mvc.perform(
-                            get(API + "/999999")
-                                    .with(httpBasic("biolab", "biolab"))
-                    )
-                    .andExpect(status().isNotFound())
-                    .andReturn().getResponse().getContentAsString();
+            String jsonResponse = mvc.perform(get(API + "/999999").with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isNotFound())
+                .andReturn().getResponse().getContentAsString();
 
             String expectedResponse = """
-                {
-                    "status" : 404,
-                    "message": "AssessmentMetric not found by id: 999999"
-                }
-                """;
+                { "status": 404, "message": "AssessmentMetric not found by id: 999999" }
+            """;
 
-            JsonNode expectedNode = objectMapper.readTree(expectedResponse);
-            JsonNode actualNode   = objectMapper.readTree(jsonResponse);
-
-            assertEquals(expectedNode, actualNode);
+            assertEquals(objectMapper.readTree(expectedResponse), objectMapper.readTree(jsonResponse));
         }
-
     }
 
     @Nested
@@ -292,95 +200,55 @@ class AssessmentMetricControllerIntegrationTest {
         @DisplayName("PUT /assessmentMetrics -> updates and returns the AssessmentMetric")
         void update() throws Exception {
             AssessmentMetric original = assessmentMetricRepository.save(AssessmentMetric.builder()
-                    .assessmentId(assessment.getId())
-                    .conditionalMetricId(conditionalMetric.getId())
-                    .dataSourceId(dataSource.getId())
-                    .minValue(1)
-                    .maxValue(2)
-                    .avgValue(3)
-                    .lastValue(4)
-                    .build());
+                .assessmentId(assessment.getId()).conditionalMetricId(conditionalMetric.getId())
+                .dataSourceId(dataSource.getId()).minValue(1).maxValue(2).avgValue(3).build());
 
-           String updateRequest = """
-                                {
-                                    "id"                  : %d,
-                                    "assessmentId"        : %d,
-                                    "conditionalMetricId" : %d,
-                                    "dataSourceId"        : %d,
-                                    "minValue"            : 4,
-                                    "maxValue"            : 5,
-                                    "avgValue"            : 6,
-                                    "lastValue"           : 7
-                                }
-                                """.formatted(original.getId(), assessment.getId(), conditionalMetric.getId(), dataSource.getId());
+            String updateRequest = """
+                {
+                    "id": %d, "assessmentId": %d, "conditionalMetricId": %d, "dataSourceId": %d,
+                    "minValue": 4, "maxValue": 5, "avgValue": 6
+                }
+            """.formatted(original.getId(), assessment.getId(), conditionalMetric.getId(), dataSource.getId());
 
-            String jsonResponse = mvc.perform(
-                            put(API)
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(updateRequest)
-                                    .with(httpBasic("biolab", "biolab"))
-                    )
-                    .andExpect(status().isOk())
-                    .andReturn().getResponse().getContentAsString();
-
-            JsonNode responseNode = objectMapper.readTree(jsonResponse);
+            String jsonResponse = mvc.perform(put(API)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(updateRequest)
+                    .with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
 
             String expectedResponse = """
-                                {
-                                    "id"                  : %d,
-                                    "assessmentId"        : %d,
-                                    "conditionalMetricId" : %d,
-                                    "dataSourceId"        : %d,
-                                    "minValue"            : 4,
-                                    "maxValue"            : 5,
-                                    "avgValue"            : 6,
-                                    "lastValue"           : 7,
-                                    "description"         : null
-                                 }
-                                """.formatted(original.getId(), assessment.getId(), conditionalMetric.getId(), dataSource.getId());
+                {
+                    "id": %d, "assessmentId": %d, "conditionalMetricId": %d, "dataSourceId": %d,
+                    "minValue": 4, "maxValue": 5, "avgValue": 6, "description": null
+                }
+            """.formatted(original.getId(), assessment.getId(), conditionalMetric.getId(), dataSource.getId());
 
-            JsonNode expectedNode = objectMapper.readTree(expectedResponse);
-
-            assertEquals(expectedNode, responseNode);
+            assertEquals(objectMapper.readTree(expectedResponse), objectMapper.readTree(jsonResponse));
         }
 
         @Test
         @DisplayName("PUT /assessmentMetrics with invalid id -> returns 404")
         void updateValidationError() throws Exception {
-
             String updateRequest = """
-                                 {
-                                     "id"                  : 999999,
-                                     "assessmentId"        : %d,
-                                     "conditionalMetricId" : %d,
-                                     "dataSourceId"        : %d
-                                 }
-                                 """.formatted(assessment.getId(), conditionalMetric.getId(), dataSource.getId());
+                {
+                    "id": 999999, "assessmentId": %d, "conditionalMetricId": %d, "dataSourceId": %d
+                }
+            """.formatted(assessment.getId(), conditionalMetric.getId(), dataSource.getId());
 
-            String jsonResponse = mvc.perform(
-                            put(API)
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .content(updateRequest)
-                                    .with(httpBasic("biolab", "biolab"))
-                    )
-                    .andExpect(status().isNotFound())
-                    .andReturn().getResponse().getContentAsString();
-
+            String jsonResponse = mvc.perform(put(API)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(updateRequest)
+                    .with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isNotFound())
+                .andReturn().getResponse().getContentAsString();
 
             String expectedResponse = """
-                {
-                    "status" : 404,
-                    "message": "AssessmentMetricService. Could not update AssessmentMetric by id: 999999"
-                }
-                """;
+                { "status": 404, "message": "AssessmentMetricService. Could not update AssessmentMetric by id: 999999" }
+            """;
 
-            JsonNode expectedNode = objectMapper.readTree(expectedResponse);
-            JsonNode actualNode   = objectMapper.readTree(jsonResponse);
-
-            assertEquals(expectedNode, actualNode);
-
+            assertEquals(objectMapper.readTree(expectedResponse), objectMapper.readTree(jsonResponse));
         }
-
     }
 
     @Nested
@@ -390,56 +258,36 @@ class AssessmentMetricControllerIntegrationTest {
         @Test
         @DisplayName("DELETE /assessmentMetrics/{id} -> deletes the AssessmentMetric")
         void delete() throws Exception {
-            AssessmentMetric assessmentMetric = assessmentMetricRepository.save(AssessmentMetric.builder()
-                    .assessmentId(assessment.getId())
-                    .conditionalMetricId(conditionalMetric.getId())
-                    .dataSourceId(dataSource.getId())
-                    .build());
+            AssessmentMetric am = assessmentMetricRepository.save(AssessmentMetric.builder()
+                .assessmentId(assessment.getId()).conditionalMetricId(conditionalMetric.getId())
+                .dataSourceId(dataSource.getId()).build());
 
-            String jsonResponse = mvc.perform(
-                            MockMvcRequestBuilders.delete(API + "/" + assessmentMetric.getId())
-                                    .with(httpBasic("biolab", "biolab"))
-                    )
-                    .andExpect(status().isOk())
-                    .andReturn().getResponse().getContentAsString();
+            String jsonResponse = mvc.perform(MockMvcRequestBuilders.delete(API + "/" + am.getId())
+                    .with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
 
             String expectedResponse = """
-                {
-                    "status" : 200,
-                    "message": "Success"
-                }
-                """;
+                { "status": 200, "message": "Success" }
+            """;
 
-            JsonNode expectedNode = objectMapper.readTree(expectedResponse);
-            JsonNode actualNode   = objectMapper.readTree(jsonResponse);
-
-            assertEquals(expectedNode, actualNode);
-
-            assertFalse(assessmentMetricRepository.existsById(assessmentMetric.getId()));
+            assertEquals(objectMapper.readTree(expectedResponse), objectMapper.readTree(jsonResponse));
+            assertFalse(assessmentMetricRepository.existsById(am.getId()));
         }
 
         @Test
         @DisplayName("DELETE /assessmentMetrics/{id} with unknown ID -> returns 404")
         void deleteValidationError() throws Exception {
-            String jsonResponse = mvc.perform(
-                            MockMvcRequestBuilders.delete(API + "/999999")
-                                    .with(httpBasic("biolab", "biolab"))
-                    )
-                    .andExpect(status().isNotFound())
-                    .andReturn().getResponse().getContentAsString();
+            String jsonResponse = mvc.perform(MockMvcRequestBuilders.delete(API + "/999999")
+                    .with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isNotFound())
+                .andReturn().getResponse().getContentAsString();
 
             String expectedResponse = """
-                {
-                    "status" : 404,
-                    "message": "AssessmentMetricService. Could not delete id: 999999"
-                }
-                """;
+                { "status": 404, "message": "AssessmentMetricService. Could not delete id: 999999" }
+            """;
 
-            JsonNode expectedNode = objectMapper.readTree(expectedResponse);
-            JsonNode actualNode   = objectMapper.readTree(jsonResponse);
-
-            assertEquals(expectedNode, actualNode);
+            assertEquals(objectMapper.readTree(expectedResponse), objectMapper.readTree(jsonResponse));
         }
     }
-
 }

--- a/src/test/java/com/biolab/launchpad/internal/web/controller/EntityFactory.java
+++ b/src/test/java/com/biolab/launchpad/internal/web/controller/EntityFactory.java
@@ -313,6 +313,25 @@ public class EntityFactory {
         );
     }
 
+    public ConditionalMetric createNegatedConditionalMetric() {
+        Condition condition = createCondition("AutoCondition");
+        Measurement measurement = createMeasurement("AutoMeasurement");
+        Metric metric = metricRepository.save(
+            Metric.builder()
+                .name("AutoNegatedMetric")
+                .measurementId(measurement.getId())
+                .negate(true)
+                .build()
+        );
+        return conditionalMetricRepository.save(
+            ConditionalMetric.builder()
+                .name("AutoNegatedConditionalMetric")
+                .conditionId(condition.getId())
+                .metricId(metric.getId())
+                .build()
+        );
+    }
+
     public RepMetric createRepMetric() {
         Rep rep                               = createRep();
         ConditionalMetric conditionalMetric   = createConditionalMetric();

--- a/src/test/java/com/biolab/launchpad/internal/web/controller/EntityFactory.java
+++ b/src/test/java/com/biolab/launchpad/internal/web/controller/EntityFactory.java
@@ -330,13 +330,13 @@ public class EntityFactory {
         repMetricRepository.deleteAll();
         sessionMetricRepository.deleteAll();
         conditionalMetricRepository.deleteAll();
-        conditionRepository.deleteAll();
         repRepository.deleteAll();
         sessionRepository.deleteAll();
         assessmentRepository.deleteAll();
+        assessmentTemplateRepository.deleteAll();
+        conditionRepository.deleteAll();
         dataSourceRepository.deleteAll();
         integrationRepository.deleteAll();
-        assessmentTemplateRepository.deleteAll();
         playerRepository.deleteAll();
         userRepository.deleteAll();
         modelRepository.deleteAll();

--- a/src/test/java/com/biolab/launchpad/internal/web/controller/EntityFactory.java
+++ b/src/test/java/com/biolab/launchpad/internal/web/controller/EntityFactory.java
@@ -265,6 +265,18 @@ public class EntityFactory {
         );
     }
 
+    public Assessment createAssessment(Integer playerId) {
+        SportDictionary sportDictionary = createSportDictionary("AutoSportDictionary");
+        AssessmentTemplate assessmentTemplate = createAssessmentTemplate("AutoAssessmentTemplate");
+        return assessmentRepository.save(
+                Assessment.builder()
+                        .sport(sportDictionary.getId())
+                        .playerId(playerId)
+                        .templateId(assessmentTemplate.getId())
+                        .build()
+        );
+    }
+
     public Session createSession() {
         Assessment assessment = createAssessment();
         return sessionRepository.save(
@@ -313,16 +325,20 @@ public class EntityFactory {
         );
     }
 
-    public ConditionalMetric createNegatedConditionalMetric() {
-        Condition condition = createCondition("AutoCondition");
+    private Metric createNegatedMetric(String name) {
         Measurement measurement = createMeasurement("AutoMeasurement");
-        Metric metric = metricRepository.save(
+        return metricRepository.save(
             Metric.builder()
-                .name("AutoNegatedMetric")
+                .name(name)
                 .measurementId(measurement.getId())
                 .negate(true)
                 .build()
         );
+    }
+
+    public ConditionalMetric createNegatedConditionalMetric() {
+        Condition condition = createCondition("AutoCondition");
+        Metric metric       = createNegatedMetric("AutoNegatedMetric");
         return conditionalMetricRepository.save(
             ConditionalMetric.builder()
                 .name("AutoNegatedConditionalMetric")

--- a/src/test/java/com/biolab/launchpad/internal/web/controller/PlayerMetricsIntegrationTest.java
+++ b/src/test/java/com/biolab/launchpad/internal/web/controller/PlayerMetricsIntegrationTest.java
@@ -1,0 +1,204 @@
+package com.biolab.launchpad.internal.web.controller;
+
+import com.biolab.TestcontainersConfiguration;
+import com.biolab.launchpad.internal.repository.RepMetricRepository;
+import com.biolab.launchpad.internal.repository.RepRepository;
+import com.biolab.launchpad.internal.repository.SessionRepository;
+import com.biolab.launchpad.internal.repository.model.Rep;
+import com.biolab.launchpad.internal.repository.model.RepMetric;
+import com.biolab.launchpad.internal.repository.model.Session;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({TestcontainersConfiguration.class, EntityFactory.class})
+@DisplayName("Player Metrics Integration Tests")
+class PlayerMetricsIntegrationTest {
+
+    private static final String SESSIONS_API = "/api/v1/sessions";
+    private static final String PLAYERS_API  = "/api/v1/players";
+
+    @Autowired MockMvc mvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired EntityFactory entityFactory;
+    @Autowired SessionRepository sessionRepository;
+    @Autowired RepRepository repRepository;
+    @Autowired RepMetricRepository repMetricRepository;
+
+    @AfterEach
+    void tearDown() {
+        entityFactory.cleanup();
+    }
+
+    @Test
+    @DisplayName("Player with no assessments -> returns empty overall and assessments")
+    void noAssessments() throws Exception {
+        var player = entityFactory.createPlayer("TestPlayer");
+
+        String json = mvc.perform(get(PLAYERS_API + "/" + player.getId() + "/metrics")
+                        .with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode root = objectMapper.readTree(json);
+        assertTrue(root.get("overall").isEmpty());
+        assertTrue(root.get("assessments").isEmpty());
+    }
+
+    @Test
+    @DisplayName("One assessment, non-negated metric -> correct min/max/avg in assessments and overall")
+    void oneAssessmentNonNegated() throws Exception {
+        var player     = entityFactory.createPlayer("TestPlayer");
+        var cm         = entityFactory.createConditionalMetric();
+        var assessment = entityFactory.createAssessment(player.getId());
+        entityFactory.createAssessmentMetric(assessment.getId(), cm.getId());
+
+        var session = sessionRepository.save(Session.builder()
+                .assessmentId(assessment.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 0)))
+                .status("ACTIVE").build());
+        var rep1 = repRepository.save(Rep.builder().sessionId(session.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 1))).build());
+        var rep2 = repRepository.save(Rep.builder().sessionId(session.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 2))).build());
+        repMetricRepository.save(RepMetric.builder().repId(rep1.getId())
+                .conditionalMetricId(cm.getId()).value(10.0).build());
+        repMetricRepository.save(RepMetric.builder().repId(rep2.getId())
+                .conditionalMetricId(cm.getId()).value(20.0).build());
+        mvc.perform(post(SESSIONS_API + "/" + session.getId() + "/stop")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic("biolab", "biolab"))).andExpect(status().isOk());
+
+        String json = mvc.perform(get(PLAYERS_API + "/" + player.getId() + "/metrics")
+                        .with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode root   = objectMapper.readTree(json);
+        JsonNode metric = root.get("assessments").get(0).get("metrics").get(0);
+        assertEquals(10.0, metric.get("minValue").asDouble(), 0.001);
+        assertEquals(20.0, metric.get("maxValue").asDouble(), 0.001);
+        assertEquals(15.0, metric.get("avgValue").asDouble(), 0.001);
+        assertFalse(metric.get("negated").asBoolean());
+
+        JsonNode overall = root.get("overall").get(0);
+        assertEquals(10.0, overall.get("minValue").asDouble(), 0.001);
+        assertEquals(20.0, overall.get("maxValue").asDouble(), 0.001);
+        assertEquals(15.0, overall.get("avgValue").asDouble(), 0.001);
+    }
+
+    @Test
+    @DisplayName("One assessment, negated metric -> min/max swapped in assessments and overall")
+    void oneAssessmentNegated() throws Exception {
+        var player     = entityFactory.createPlayer("TestPlayer");
+        var cm         = entityFactory.createNegatedConditionalMetric();
+        var assessment = entityFactory.createAssessment(player.getId());
+        entityFactory.createAssessmentMetric(assessment.getId(), cm.getId());
+
+        var session = sessionRepository.save(Session.builder()
+                .assessmentId(assessment.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 0)))
+                .status("ACTIVE").build());
+        var rep1 = repRepository.save(Rep.builder().sessionId(session.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 1))).build());
+        var rep2 = repRepository.save(Rep.builder().sessionId(session.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 2))).build());
+        repMetricRepository.save(RepMetric.builder().repId(rep1.getId())
+                .conditionalMetricId(cm.getId()).value(10.0).build());
+        repMetricRepository.save(RepMetric.builder().repId(rep2.getId())
+                .conditionalMetricId(cm.getId()).value(20.0).build());
+        mvc.perform(post(SESSIONS_API + "/" + session.getId() + "/stop")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic("biolab", "biolab"))).andExpect(status().isOk());
+
+        String json = mvc.perform(get(PLAYERS_API + "/" + player.getId() + "/metrics")
+                        .with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode root   = objectMapper.readTree(json);
+        JsonNode metric = root.get("assessments").get(0).get("metrics").get(0);
+        assertEquals(20.0, metric.get("minValue").asDouble(), 0.001);
+        assertEquals(10.0, metric.get("maxValue").asDouble(), 0.001);
+        assertEquals(15.0, metric.get("avgValue").asDouble(), 0.001);
+        assertTrue(metric.get("negated").asBoolean());
+
+        JsonNode overall = root.get("overall").get(0);
+        assertEquals(20.0, overall.get("minValue").asDouble(), 0.001);
+        assertEquals(10.0, overall.get("maxValue").asDouble(), 0.001);
+        assertEquals(15.0, overall.get("avgValue").asDouble(), 0.001);
+    }
+
+    @Test
+    @DisplayName("Two assessments, same conditionalMetricId -> overall rolls up correctly")
+    void twoAssessmentsSameMetric() throws Exception {
+        var player = entityFactory.createPlayer("TestPlayer");
+        var cm     = entityFactory.createConditionalMetric();
+
+        // Assessment 1: values [10.0, 20.0] -> min=10, max=20, avg=15
+        var a1 = entityFactory.createAssessment(player.getId());
+        entityFactory.createAssessmentMetric(a1.getId(), cm.getId());
+        var s1  = sessionRepository.save(Session.builder().assessmentId(a1.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 0))).status("ACTIVE").build());
+        var r1a = repRepository.save(Rep.builder().sessionId(s1.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 1))).build());
+        var r1b = repRepository.save(Rep.builder().sessionId(s1.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 2))).build());
+        repMetricRepository.save(RepMetric.builder().repId(r1a.getId()).conditionalMetricId(cm.getId()).value(10.0).build());
+        repMetricRepository.save(RepMetric.builder().repId(r1b.getId()).conditionalMetricId(cm.getId()).value(20.0).build());
+        mvc.perform(post(SESSIONS_API + "/" + s1.getId() + "/stop")
+                .contentType(MediaType.APPLICATION_JSON).with(httpBasic("biolab", "biolab"))).andExpect(status().isOk());
+
+        // Assessment 2: values [30.0, 40.0] -> min=30, max=40, avg=35
+        var a2 = entityFactory.createAssessment(player.getId());
+        entityFactory.createAssessmentMetric(a2.getId(), cm.getId());
+        var s2  = sessionRepository.save(Session.builder().assessmentId(a2.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 46, 0))).status("ACTIVE").build());
+        var r2a = repRepository.save(Rep.builder().sessionId(s2.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 46, 1))).build());
+        var r2b = repRepository.save(Rep.builder().sessionId(s2.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 46, 2))).build());
+        repMetricRepository.save(RepMetric.builder().repId(r2a.getId()).conditionalMetricId(cm.getId()).value(30.0).build());
+        repMetricRepository.save(RepMetric.builder().repId(r2b.getId()).conditionalMetricId(cm.getId()).value(40.0).build());
+        mvc.perform(post(SESSIONS_API + "/" + s2.getId() + "/stop")
+                .contentType(MediaType.APPLICATION_JSON).with(httpBasic("biolab", "biolab"))).andExpect(status().isOk());
+
+        String json = mvc.perform(get(PLAYERS_API + "/" + player.getId() + "/metrics")
+                        .with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode root = objectMapper.readTree(json);
+        assertEquals(2, root.get("assessments").size());
+
+        JsonNode overall = root.get("overall").get(0);
+        assertEquals(10.0, overall.get("minValue").asDouble(), 0.001);
+        assertEquals(40.0, overall.get("maxValue").asDouble(), 0.001);
+        assertEquals(25.0, overall.get("avgValue").asDouble(), 0.001);
+    }
+
+    @Test
+    @DisplayName("Player not found -> 404")
+    void playerNotFound() throws Exception {
+        mvc.perform(get(PLAYERS_API + "/999999/metrics")
+                        .with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/biolab/launchpad/internal/web/controller/SessionWorkflowIntegrationTest.java
+++ b/src/test/java/com/biolab/launchpad/internal/web/controller/SessionWorkflowIntegrationTest.java
@@ -229,7 +229,6 @@ class SessionWorkflowIntegrationTest {
             assertEquals(10.0, updated.getMinValue().doubleValue(), 0.001);
             assertEquals(20.0, updated.getMaxValue().doubleValue(), 0.001);
             assertEquals(15.0, updated.getAvgValue().doubleValue(), 0.001);
-            assertEquals(15.0, updated.getLastValue().doubleValue(), 0.001);
         }
     }
 }

--- a/src/test/java/com/biolab/launchpad/internal/web/controller/SessionWorkflowIntegrationTest.java
+++ b/src/test/java/com/biolab/launchpad/internal/web/controller/SessionWorkflowIntegrationTest.java
@@ -189,6 +189,44 @@ class SessionWorkflowIntegrationTest {
         }
 
         @Test
+        @DisplayName("POST /sessions/{id}/stop with negated metric swaps min and max")
+        void stopNegatedMetricSwapsMinMax() throws Exception {
+            var cm = entityFactory.createNegatedConditionalMetric();
+            var assessment = entityFactory.createAssessment();
+            var am = entityFactory.createAssessmentMetric(assessment.getId(), cm.getId());
+
+            var session = sessionRepository.save(Session.builder()
+                .assessmentId(assessment.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 1)))
+                .status("ACTIVE")
+                .build());
+
+            var rep1 = repRepository.save(Rep.builder()
+                .sessionId(session.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 1)))
+                .build());
+            var rep2 = repRepository.save(Rep.builder()
+                .sessionId(session.getId())
+                .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 2)))
+                .build());
+            repMetricRepository.save(RepMetric.builder()
+                .repId(rep1.getId()).conditionalMetricId(cm.getId()).value(10.0).build());
+            repMetricRepository.save(RepMetric.builder()
+                .repId(rep2.getId()).conditionalMetricId(cm.getId()).value(20.0).build());
+
+            mvc.perform(post(API + "/" + session.getId() + "/stop")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic("biolab", "biolab")))
+                .andExpect(status().isOk());
+
+            var updated = assessmentMetricRepository.findById(am.getId()).orElseThrow();
+            // negated: larger raw value → minValue (worst); smaller raw value → maxValue (best)
+            assertEquals(20.0, updated.getMinValue().doubleValue(), 0.001);
+            assertEquals(10.0, updated.getMaxValue().doubleValue(), 0.001);
+            assertEquals(15.0, updated.getAvgValue().doubleValue(), 0.001);
+        }
+
+        @Test
         @DisplayName("POST /sessions/{id}/stop aggregates rep metrics into AssessmentMetric")
         void stopComputesAssessmentMetricAggregates() throws Exception {
             var cm = entityFactory.createConditionalMetric();


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/players/{id}/metrics` — returns min/max/avg aggregates for all assessments of a player, grouped by assessment with an overall rollup
- Drop `last_value` column from `assessment_metric` (redundant with session-level data)
- Negate-aware aggregation: for metrics where lower is better (`Metric.negate=true`), min/max semantics are inverted at storage time so `maxValue` always represents best performance

## Test Plan
- [ ] `PlayerMetricsIntegrationTest` — 5 scenarios: no assessments, non-negated metric, negated metric, two-assessment rollup, 404
- [ ] `SessionWorkflowIntegrationTest` — existing tests + new `stopNegatedMetricSwapsMinMax`
- [ ] Full suite: `./gradlew test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)