### PR TITLE
[BL-39] Assessment metric lock rules, session/rep counters, and assessment creation from template

### DIFF
--- a/src/main/java/com/biolab/launchpad/internal/repository/SessionRepository.java
+++ b/src/main/java/com/biolab/launchpad/internal/repository/SessionRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Repository("assessmentSessionRepository")
 public interface SessionRepository extends CrudRepository<Session, Integer> {
     List<Session> findAllByAssessmentId(Integer assessmentId);
+    long countByAssessmentId(Integer assessmentId);
 }

--- a/src/main/java/com/biolab/launchpad/internal/repository/TemplateMetricRepository.java
+++ b/src/main/java/com/biolab/launchpad/internal/repository/TemplateMetricRepository.java
@@ -4,6 +4,9 @@ import com.biolab.launchpad.internal.repository.model.TemplateMetric;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface TemplateMetricRepository extends CrudRepository<TemplateMetric, Integer> {
+    List<TemplateMetric> findByTemplateId(Integer templateId);
 }

--- a/src/main/java/com/biolab/launchpad/internal/repository/model/AssessmentMetric.java
+++ b/src/main/java/com/biolab/launchpad/internal/repository/model/AssessmentMetric.java
@@ -28,4 +28,8 @@ public class AssessmentMetric extends ID {
     @Column("avg_value")
     private Number avgValue;
     private String description;
+    @Column("session_count")
+    private int sessionCount;
+    @Column("rep_count")
+    private int repCount;
 }

--- a/src/main/java/com/biolab/launchpad/internal/security/exceptions/BadRequestException.java
+++ b/src/main/java/com/biolab/launchpad/internal/security/exceptions/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.biolab.launchpad.internal.security.exceptions;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message, Object... args) {
+        super(message.formatted(args));
+    }
+}

--- a/src/main/java/com/biolab/launchpad/internal/service/AssessmentMetricService.java
+++ b/src/main/java/com/biolab/launchpad/internal/service/AssessmentMetricService.java
@@ -1,17 +1,47 @@
 package com.biolab.launchpad.internal.service;
 
+import com.biolab.launchpad.internal.repository.AssessmentMetricRepository;
+import com.biolab.launchpad.internal.repository.SessionRepository;
 import com.biolab.launchpad.internal.repository.model.AssessmentMetric;
+import com.biolab.launchpad.internal.security.exceptions.ConflictException;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Service;
 
 @Service
 @Log4j2
 public class AssessmentMetricService extends EntityServiceID<AssessmentMetric> {
+
+    private final AssessmentMetricRepository assessmentMetricRepository;
+    private final SessionRepository sessionRepository;
+
     @Autowired
-    public AssessmentMetricService(CrudRepository<AssessmentMetric, Integer> repository) {
-        super(repository);
+    public AssessmentMetricService(AssessmentMetricRepository assessmentMetricRepository,
+                                   SessionRepository sessionRepository) {
+        super(assessmentMetricRepository);
+        this.assessmentMetricRepository = assessmentMetricRepository;
+        this.sessionRepository = sessionRepository;
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        assessmentMetricRepository.findById(id).ifPresent(metric -> {
+            if (sessionRepository.countByAssessmentId(metric.getAssessmentId()) > 0) {
+                throw new ConflictException(
+                    "Cannot delete assessment metric — assessment %d has sessions".formatted(metric.getAssessmentId())
+                );
+            }
+        });
+        super.deleteById(id);
+    }
+
+    @Override
+    public AssessmentMetric update(AssessmentMetric metric) {
+        if (sessionRepository.countByAssessmentId(metric.getAssessmentId()) > 0) {
+            throw new ConflictException(
+                "Cannot update assessment metric — assessment %d has sessions".formatted(metric.getAssessmentId())
+            );
+        }
+        return super.update(metric);
     }
 }
-

--- a/src/main/java/com/biolab/launchpad/internal/service/AssessmentService.java
+++ b/src/main/java/com/biolab/launchpad/internal/service/AssessmentService.java
@@ -1,6 +1,9 @@
 package com.biolab.launchpad.internal.service;
 
+import com.biolab.launchpad.internal.repository.AssessmentMetricRepository;
+import com.biolab.launchpad.internal.repository.TemplateMetricRepository;
 import com.biolab.launchpad.internal.repository.model.Assessment;
+import com.biolab.launchpad.internal.repository.model.AssessmentMetric;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.repository.CrudRepository;
@@ -9,9 +12,31 @@ import org.springframework.stereotype.Service;
 @Service
 @Log4j2
 public class AssessmentService extends EntityServiceID<Assessment> {
+
+    private final TemplateMetricRepository templateMetricRepository;
+    private final AssessmentMetricRepository assessmentMetricRepository;
+
     @Autowired
-    public AssessmentService(CrudRepository<Assessment, Integer> repository) {
+    public AssessmentService(CrudRepository<Assessment, Integer> repository,
+                             TemplateMetricRepository templateMetricRepository,
+                             AssessmentMetricRepository assessmentMetricRepository) {
         super(repository);
+        this.templateMetricRepository = templateMetricRepository;
+        this.assessmentMetricRepository = assessmentMetricRepository;
+    }
+
+    @Override
+    public Assessment create(Assessment assessment) {
+        Assessment saved = super.create(assessment);
+        templateMetricRepository.findByTemplateId(assessment.getTemplateId()).forEach(tm -> {
+            AssessmentMetric am = AssessmentMetric.builder()
+                    .assessmentId(saved.getId())
+                    .conditionalMetricId(tm.getConditionalMetricId())
+                    .dataSourceId(tm.getDataSourceId())
+                    .description(tm.getDescription())
+                    .build();
+            assessmentMetricRepository.save(am);
+        });
+        return saved;
     }
 }
-

--- a/src/main/java/com/biolab/launchpad/internal/service/RepMetricService.java
+++ b/src/main/java/com/biolab/launchpad/internal/service/RepMetricService.java
@@ -1,17 +1,47 @@
 package com.biolab.launchpad.internal.service;
 
+import com.biolab.launchpad.internal.repository.AssessmentMetricRepository;
+import com.biolab.launchpad.internal.repository.RepMetricRepository;
+import com.biolab.launchpad.internal.repository.RepRepository;
+import com.biolab.launchpad.internal.repository.SessionRepository;
 import com.biolab.launchpad.internal.repository.model.RepMetric;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Service;
 
 
 @Service
 @Log4j2
 public class RepMetricService extends EntityServiceID<RepMetric> {
+
+    private final RepRepository repRepository;
+    private final SessionRepository sessionRepository;
+    private final AssessmentMetricRepository assessmentMetricRepository;
+
     @Autowired
-    public RepMetricService(CrudRepository<RepMetric, Integer> repository) {
-        super(repository);
+    public RepMetricService(RepMetricRepository repMetricRepository,
+                            RepRepository repRepository,
+                            SessionRepository sessionRepository,
+                            AssessmentMetricRepository assessmentMetricRepository) {
+        super(repMetricRepository);
+        this.repRepository = repRepository;
+        this.sessionRepository = sessionRepository;
+        this.assessmentMetricRepository = assessmentMetricRepository;
+    }
+
+    @Override
+    public RepMetric create(RepMetric repMetric) {
+        RepMetric saved = super.create(repMetric);
+        repRepository.findById(repMetric.getRepId()).ifPresent(rep ->
+            sessionRepository.findById(rep.getSessionId()).ifPresent(session ->
+                assessmentMetricRepository
+                    .findByAssessmentIdAndConditionalMetricId(session.getAssessmentId(), repMetric.getConditionalMetricId())
+                    .ifPresent(am -> {
+                        am.setRepCount(am.getRepCount() + 1);
+                        assessmentMetricRepository.save(am);
+                    })
+            )
+        );
+        return saved;
     }
 }

--- a/src/main/java/com/biolab/launchpad/internal/service/SessionMetricService.java
+++ b/src/main/java/com/biolab/launchpad/internal/service/SessionMetricService.java
@@ -1,17 +1,41 @@
 package com.biolab.launchpad.internal.service;
 
+import com.biolab.launchpad.internal.repository.AssessmentMetricRepository;
+import com.biolab.launchpad.internal.repository.SessionMetricRepository;
+import com.biolab.launchpad.internal.repository.SessionRepository;
 import com.biolab.launchpad.internal.repository.model.SessionMetric;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Service;
 
 
 @Service
 @Log4j2
 public class SessionMetricService extends EntityServiceID<SessionMetric> {
+
+    private final SessionRepository sessionRepository;
+    private final AssessmentMetricRepository assessmentMetricRepository;
+
     @Autowired
-    public SessionMetricService(CrudRepository<SessionMetric, Integer> repository) {
-        super(repository);
+    public SessionMetricService(SessionMetricRepository sessionMetricRepository,
+                                SessionRepository sessionRepository,
+                                AssessmentMetricRepository assessmentMetricRepository) {
+        super(sessionMetricRepository);
+        this.sessionRepository = sessionRepository;
+        this.assessmentMetricRepository = assessmentMetricRepository;
+    }
+
+    @Override
+    public SessionMetric create(SessionMetric sessionMetric) {
+        SessionMetric saved = super.create(sessionMetric);
+        sessionRepository.findById(sessionMetric.getSessionId()).ifPresent(session ->
+            assessmentMetricRepository
+                .findByAssessmentIdAndConditionalMetricId(session.getAssessmentId(), sessionMetric.getConditionalMetricId())
+                .ifPresent(am -> {
+                    am.setSessionCount(am.getSessionCount() + 1);
+                    assessmentMetricRepository.save(am);
+                })
+        );
+        return saved;
     }
 }

--- a/src/main/java/com/biolab/launchpad/internal/service/SessionService.java
+++ b/src/main/java/com/biolab/launchpad/internal/service/SessionService.java
@@ -1,17 +1,34 @@
 package com.biolab.launchpad.internal.service;
 
+import com.biolab.launchpad.internal.repository.AssessmentMetricRepository;
+import com.biolab.launchpad.internal.repository.SessionRepository;
 import com.biolab.launchpad.internal.repository.model.Session;
+import com.biolab.launchpad.internal.security.exceptions.BadRequestException;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Service;
 
 
 @Service
 @Log4j2
 public class SessionService extends EntityServiceID<Session> {
+
+    private final AssessmentMetricRepository assessmentMetricRepository;
+
     @Autowired
-    public SessionService(CrudRepository<Session, Integer> repository) {
-        super(repository);
+    public SessionService(SessionRepository sessionRepository,
+                          AssessmentMetricRepository assessmentMetricRepository) {
+        super(sessionRepository);
+        this.assessmentMetricRepository = assessmentMetricRepository;
+    }
+
+    @Override
+    public Session create(Session session) {
+        if (assessmentMetricRepository.findAllByAssessmentId(session.getAssessmentId()).isEmpty()) {
+            throw new BadRequestException(
+                "Cannot start session — assessment %d has no metrics".formatted(session.getAssessmentId())
+            );
+        }
+        return super.create(session);
     }
 }

--- a/src/main/java/com/biolab/launchpad/internal/web/controller/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/biolab/launchpad/internal/web/controller/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.biolab.launchpad.internal.web.controller.exception;
 
+import com.biolab.launchpad.internal.security.exceptions.BadRequestException;
 import com.biolab.launchpad.internal.security.exceptions.ConflictException;
 import com.biolab.launchpad.internal.security.exceptions.NotFoundByException;
 import com.biolab.launchpad.internal.web.dto.ResponseCode;
@@ -53,6 +54,16 @@ public class GlobalExceptionHandler {
     public ResponseDto handleNotFoundByException(NotFoundByException ex) {
         return ResponseDto.builder()
                 .status(ResponseCode.NOT_FOUND_BY.getStatus())
+                .message(ex.getMessage())
+                .build();
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseDto handleBadRequestException(BadRequestException ex) {
+        log.warn(ex.getMessage());
+        return ResponseDto.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
                 .message(ex.getMessage())
                 .build();
     }

--- a/src/main/java/com/biolab/launchpad/internal/web/dto/AssessmentMetricDto.java
+++ b/src/main/java/com/biolab/launchpad/internal/web/dto/AssessmentMetricDto.java
@@ -15,5 +15,7 @@ public record AssessmentMetricDto(
         Number minValue,
         Number maxValue,
         Number avgValue,
-        String description
+        String description,
+        int sessionCount,
+        int repCount
 ){}

--- a/src/main/resources/db/changelog/biolab.changelog.yml
+++ b/src/main/resources/db/changelog/biolab.changelog.yml
@@ -15,4 +15,6 @@ databaseChangeLog:
       file: db/changelog/changeset/3_bl_28.yml
   - include:
       file: db/changelog/changeset/1_bl_52.yml
+  - include:
+      file: db/changelog/changeset/1_bl_39.yml
 

--- a/src/main/resources/db/changelog/changeset/1_bl_39.yml
+++ b/src/main/resources/db/changelog/changeset/1_bl_39.yml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1-BL-39-1
+      author: roman.vakulenko
+      changes:
+        - addColumn:
+            tableName: assessment_metric
+            columns:
+              - column:
+                  name: session_count
+                  type: integer
+                  constraints:
+                    nullable: false
+                  defaultValue: 0
+        - addColumn:
+            tableName: assessment_metric
+            columns:
+              - column:
+                  name: rep_count
+                  type: integer
+                  constraints:
+                    nullable: false
+                  defaultValue: 0

--- a/src/test/java/com/biolab/launchpad/internal/service/AssessmentMetricServiceTest.java
+++ b/src/test/java/com/biolab/launchpad/internal/service/AssessmentMetricServiceTest.java
@@ -1,7 +1,9 @@
 package com.biolab.launchpad.internal.service;
 
 import com.biolab.launchpad.internal.repository.AssessmentMetricRepository;
+import com.biolab.launchpad.internal.repository.SessionRepository;
 import com.biolab.launchpad.internal.repository.model.AssessmentMetric;
+import com.biolab.launchpad.internal.security.exceptions.ConflictException;
 import com.biolab.launchpad.internal.security.exceptions.NotFoundByException;
 import com.biolab.launchpad.internal.security.exceptions.PersistException;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +29,9 @@ class AssessmentMetricServiceTest {
     @Mock
     private AssessmentMetricRepository assessmentMetricRepository;
 
+    @Mock
+    private SessionRepository sessionRepository;
+
     @InjectMocks
     private AssessmentMetricService assessmentMetricService;
 
@@ -41,6 +46,7 @@ class AssessmentMetricServiceTest {
 
         assessmentMetric1 = AssessmentMetric.builder()
                 .id(1)
+                .assessmentId(10)
                 .build();
 
         assessmentMetric2 = AssessmentMetric.builder()
@@ -119,35 +125,50 @@ class AssessmentMetricServiceTest {
     @DisplayName("deleteById()")
     class DeleteByIdTests {
         @Test
-        @DisplayName("should delete assessment_metric when it exists")
+        @DisplayName("should delete assessment_metric when no sessions exist")
         void deleteById_when_exists_deletes() {
+            when(assessmentMetricRepository.findById(1)).thenReturn(Optional.of(assessmentMetric1));
+            when(sessionRepository.countByAssessmentId(10)).thenReturn(0L);
             when(assessmentMetricRepository.existsById(1)).thenReturn(true);
 
             assessmentMetricService.deleteById(1);
 
+            verify(assessmentMetricRepository).findById(1);
+            verify(sessionRepository).countByAssessmentId(10);
             verify(assessmentMetricRepository).existsById(1);
             verify(assessmentMetricRepository).deleteById(1);
             verifyNoMoreInteractions(assessmentMetricRepository);
         }
 
         @Test
+        @DisplayName("should throw ConflictException when assessment has sessions")
+        void deleteById_throws_ConflictException_whenAssessmentHasSessions() {
+            when(assessmentMetricRepository.findById(1)).thenReturn(Optional.of(assessmentMetric1));
+            when(sessionRepository.countByAssessmentId(10)).thenReturn(1L);
+
+            assertThrows(ConflictException.class, () -> assessmentMetricService.deleteById(1));
+            verify(assessmentMetricRepository, never()).deleteById(anyInt());
+        }
+
+        @Test
         @DisplayName("should throw NotFoundByException when assessment_metric does not exist")
         void deleteById_when_not_exists_throws_NotFoundByException() {
+            when(assessmentMetricRepository.findById(1)).thenReturn(Optional.empty());
             when(assessmentMetricRepository.existsById(1)).thenReturn(false);
 
             assertThrows(NotFoundByException.class, () -> assessmentMetricService.deleteById(1));
             verify(assessmentMetricRepository, never()).deleteById(anyInt());
-            verifyNoMoreInteractions(assessmentMetricRepository);
         }
 
         @Test
         @DisplayName("should wrap unexpected repo exception in PersistException")
         void deleteById_wraps_other_exceptions_in_PersistException() {
+            when(assessmentMetricRepository.findById(1)).thenReturn(Optional.of(assessmentMetric1));
+            when(sessionRepository.countByAssessmentId(10)).thenReturn(0L);
             when(assessmentMetricRepository.existsById(1)).thenReturn(true);
             doThrow(new RuntimeException("constraint fail")).when(assessmentMetricRepository).deleteById(1);
 
             assertThrows(PersistException.class, () -> assessmentMetricService.deleteById(1));
-            verifyNoMoreInteractions(assessmentMetricRepository);
         }
     }
 
@@ -155,8 +176,9 @@ class AssessmentMetricServiceTest {
     @DisplayName("update()")
     class UpdateTests {
         @Test
-        @DisplayName("should update and return assessment_metric when it exists")
+        @DisplayName("should update and return assessment_metric when no sessions exist")
         void update_when_exists_saves_and_returns() {
+            when(sessionRepository.countByAssessmentId(10)).thenReturn(0L);
             when(assessmentMetricRepository.existsById(1)).thenReturn(true);
             when(assessmentMetricRepository.save(assessmentMetric1)).thenReturn(assessmentMetric1);
 
@@ -169,8 +191,18 @@ class AssessmentMetricServiceTest {
         }
 
         @Test
+        @DisplayName("should throw ConflictException when assessment has sessions")
+        void update_throws_ConflictException_whenAssessmentHasSessions() {
+            when(sessionRepository.countByAssessmentId(10)).thenReturn(2L);
+
+            assertThrows(ConflictException.class, () -> assessmentMetricService.update(assessmentMetric1));
+            verify(assessmentMetricRepository, never()).save(any());
+        }
+
+        @Test
         @DisplayName("should throw NotFoundByException when assessment_metric does not exist")
         void update_when_not_exists_throws_NotFoundByException() {
+            when(sessionRepository.countByAssessmentId(10)).thenReturn(0L);
             when(assessmentMetricRepository.existsById(1)).thenReturn(false);
 
             assertThrows(NotFoundByException.class, () -> assessmentMetricService.update(assessmentMetric1));
@@ -181,6 +213,7 @@ class AssessmentMetricServiceTest {
         @Test
         @DisplayName("should wrap repo exception in PersistException")
         void update_wraps_other_exceptions_in_PersistException() {
+            when(sessionRepository.countByAssessmentId(10)).thenReturn(0L);
             when(assessmentMetricRepository.existsById(1)).thenReturn(true);
             when(assessmentMetricRepository.save(assessmentMetric1)).thenThrow(new RuntimeException("db error"));
 

--- a/src/test/java/com/biolab/launchpad/internal/service/RepMetricServiceTest.java
+++ b/src/test/java/com/biolab/launchpad/internal/service/RepMetricServiceTest.java
@@ -1,6 +1,9 @@
 package com.biolab.launchpad.internal.service;
 
+import com.biolab.launchpad.internal.repository.AssessmentMetricRepository;
 import com.biolab.launchpad.internal.repository.RepMetricRepository;
+import com.biolab.launchpad.internal.repository.RepRepository;
+import com.biolab.launchpad.internal.repository.SessionRepository;
 import com.biolab.launchpad.internal.repository.model.RepMetric;
 import com.biolab.launchpad.internal.security.exceptions.NotFoundByException;
 import com.biolab.launchpad.internal.security.exceptions.PersistException;
@@ -26,6 +29,15 @@ class RepMetricServiceTest {
 
     @Mock
     private RepMetricRepository repMetricRepository;
+
+    @Mock
+    private RepRepository repRepository;
+
+    @Mock
+    private SessionRepository sessionRepository;
+
+    @Mock
+    private AssessmentMetricRepository assessmentMetricRepository;
 
     @InjectMocks
     private RepMetricService repMetricService;
@@ -55,12 +67,12 @@ class RepMetricServiceTest {
         @DisplayName("should save and return entity when successful")
         void create_ok_saves_and_returns_entity() {
             when(repMetricRepository.save(repMetric1Input)).thenReturn(repMetric1);
+            when(repRepository.findById(null)).thenReturn(Optional.empty());
 
             RepMetric result = repMetricService.create(repMetric1Input);
 
             assertThat(result).isSameAs(repMetric1);
             verify(repMetricRepository).save(repMetric1Input);
-            verifyNoMoreInteractions(repMetricRepository);
         }
 
         @Test

--- a/src/test/java/com/biolab/launchpad/internal/service/SessionMetricServiceTest.java
+++ b/src/test/java/com/biolab/launchpad/internal/service/SessionMetricServiceTest.java
@@ -1,6 +1,8 @@
 package com.biolab.launchpad.internal.service;
 
+import com.biolab.launchpad.internal.repository.AssessmentMetricRepository;
 import com.biolab.launchpad.internal.repository.SessionMetricRepository;
+import com.biolab.launchpad.internal.repository.SessionRepository;
 import com.biolab.launchpad.internal.repository.model.SessionMetric;
 import com.biolab.launchpad.internal.security.exceptions.NotFoundByException;
 import com.biolab.launchpad.internal.security.exceptions.PersistException;
@@ -26,6 +28,12 @@ class SessionMetricServiceTest {
 
     @Mock
     private SessionMetricRepository sessionMetricRepository;
+
+    @Mock
+    private SessionRepository sessionRepository;
+
+    @Mock
+    private AssessmentMetricRepository assessmentMetricRepository;
 
     @InjectMocks
     private SessionMetricService sessionMetricService;
@@ -55,12 +63,12 @@ class SessionMetricServiceTest {
         @DisplayName("should save and return entity when successful")
         void create_ok_saves_and_returns_entity() {
             when(sessionMetricRepository.save(sessionMetric1Input)).thenReturn(sessionMetric1);
+            when(sessionRepository.findById(null)).thenReturn(Optional.empty());
 
             SessionMetric result = sessionMetricService.create(sessionMetric1Input);
 
             assertThat(result).isSameAs(sessionMetric1);
             verify(sessionMetricRepository).save(sessionMetric1Input);
-            verifyNoMoreInteractions(sessionMetricRepository);
         }
 
         @Test

--- a/src/test/java/com/biolab/launchpad/internal/service/SessionServiceTest.java
+++ b/src/test/java/com/biolab/launchpad/internal/service/SessionServiceTest.java
@@ -1,7 +1,10 @@
 package com.biolab.launchpad.internal.service;
 
+import com.biolab.launchpad.internal.repository.AssessmentMetricRepository;
 import com.biolab.launchpad.internal.repository.SessionRepository;
+import com.biolab.launchpad.internal.repository.model.AssessmentMetric;
 import com.biolab.launchpad.internal.repository.model.Session;
+import com.biolab.launchpad.internal.security.exceptions.BadRequestException;
 import com.biolab.launchpad.internal.security.exceptions.NotFoundByException;
 import com.biolab.launchpad.internal.security.exceptions.PersistException;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +30,9 @@ class SessionServiceTest {
     @Mock
     private SessionRepository sessionRepository;
 
+    @Mock
+    private AssessmentMetricRepository assessmentMetricRepository;
+
     @InjectMocks
     private SessionService sessionService;
 
@@ -37,10 +43,12 @@ class SessionServiceTest {
     @BeforeEach
     void setUp() {
         session1Input = Session.builder()
+                .assessmentId(1)
                 .build();
 
         session1 = Session.builder()
                 .id(1)
+                .assessmentId(1)
                 .build();
 
         session2 = Session.builder()
@@ -54,23 +62,34 @@ class SessionServiceTest {
         @Test
         @DisplayName("should save and return entity when successful")
         void create_ok_saves_and_returns_entity() {
+            when(assessmentMetricRepository.findAllByAssessmentId(1))
+                .thenReturn(List.of(AssessmentMetric.builder().id(1).build()));
             when(sessionRepository.save(session1Input)).thenReturn(session1);
 
             Session result = sessionService.create(session1Input);
 
             assertThat(result).isSameAs(session1);
             verify(sessionRepository).save(session1Input);
-            verifyNoMoreInteractions(sessionRepository);
+        }
+
+        @Test
+        @DisplayName("should throw BadRequestException when assessment has no metrics")
+        void create_throws_BadRequestException_whenNoMetrics() {
+            when(assessmentMetricRepository.findAllByAssessmentId(1)).thenReturn(List.of());
+
+            assertThrows(BadRequestException.class, () -> sessionService.create(session1Input));
+            verify(sessionRepository, never()).save(any());
         }
 
         @Test
         @DisplayName("should wrap repo exception in PersistException")
         void create_wraps_any_exception_in_PersistException() {
+            when(assessmentMetricRepository.findAllByAssessmentId(1))
+                .thenReturn(List.of(AssessmentMetric.builder().id(1).build()));
             when(sessionRepository.save(session1Input)).thenThrow(new RuntimeException("db down"));
 
             PersistException ex = assertThrows(PersistException.class, () -> sessionService.create(session1Input));
             assertTrue(ex.getMessage().contains("db down"));
-            verifyNoMoreInteractions(sessionRepository);
         }
     }
 

--- a/src/test/java/com/biolab/launchpad/internal/web/controller/AssessmentMetricControllerIntegrationTest.java
+++ b/src/test/java/com/biolab/launchpad/internal/web/controller/AssessmentMetricControllerIntegrationTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
@@ -88,7 +89,9 @@ class AssessmentMetricControllerIntegrationTest {
                     "minValue"            : 1,
                     "maxValue"            : 2,
                     "avgValue"            : 3,
-                    "description"         : null
+                    "description"         : null,
+                    "sessionCount"        : 0,
+                    "repCount"            : 0
                 }
             """.formatted(id, assessment.getId(), conditionalMetric.getId(), dataSource.getId());
 
@@ -143,11 +146,13 @@ class AssessmentMetricControllerIntegrationTest {
                 [
                     {
                         "id": %d, "assessmentId": %d, "conditionalMetricId": %d, "dataSourceId": %d,
-                        "minValue": 1, "maxValue": 2, "avgValue": 3, "description": null
+                        "minValue": 1, "maxValue": 2, "avgValue": 3, "description": null,
+                        "sessionCount": 0, "repCount": 0
                     },
                     {
                         "id": %d, "assessmentId": %d, "conditionalMetricId": %d, "dataSourceId": %d,
-                        "minValue": 5, "maxValue": 6, "avgValue": 7, "description": null
+                        "minValue": 5, "maxValue": 6, "avgValue": 7, "description": null,
+                        "sessionCount": 0, "repCount": 0
                     }
                 ]
             """.formatted(am1.getId(), assessment.getId(), conditionalMetric.getId(), dataSource.getId(),
@@ -170,7 +175,8 @@ class AssessmentMetricControllerIntegrationTest {
             String expectedResponse = """
                 {
                     "id": %d, "assessmentId": %d, "conditionalMetricId": %d, "dataSourceId": %d,
-                    "minValue": 1, "maxValue": 2, "avgValue": 3, "description": null
+                    "minValue": 1, "maxValue": 2, "avgValue": 3, "description": null,
+                    "sessionCount": 0, "repCount": 0
                 }
             """.formatted(am.getId(), assessment.getId(), conditionalMetric.getId(), dataSource.getId());
 
@@ -220,7 +226,8 @@ class AssessmentMetricControllerIntegrationTest {
             String expectedResponse = """
                 {
                     "id": %d, "assessmentId": %d, "conditionalMetricId": %d, "dataSourceId": %d,
-                    "minValue": 4, "maxValue": 5, "avgValue": 6, "description": null
+                    "minValue": 4, "maxValue": 5, "avgValue": 6, "description": null,
+                    "sessionCount": 0, "repCount": 0
                 }
             """.formatted(original.getId(), assessment.getId(), conditionalMetric.getId(), dataSource.getId());
 
@@ -288,6 +295,98 @@ class AssessmentMetricControllerIntegrationTest {
             """;
 
             assertEquals(objectMapper.readTree(expectedResponse), objectMapper.readTree(jsonResponse));
+        }
+    }
+
+    @Nested
+    @DisplayName("lock guards")
+    class LockGuardTests {
+
+        @Test
+        @DisplayName("DELETE returns 409 when assessment has sessions")
+        void delete_returns409_whenAssessmentHasSessions() throws Exception {
+            AssessmentMetric metric = factory.createAssessmentMetric();
+            factory.createSessionForAssessment(metric.getAssessmentId());
+
+            mvc.perform(delete(API + "/" + metric.getId())
+                    .with(httpBasic("biolab", "biolab")))
+               .andExpect(status().isConflict());
+        }
+
+        @Test
+        @DisplayName("PUT returns 409 when assessment has sessions")
+        void update_returns409_whenAssessmentHasSessions() throws Exception {
+            AssessmentMetric metric = factory.createAssessmentMetric();
+            factory.createSessionForAssessment(metric.getAssessmentId());
+
+            String body = """
+                    {"id":%d,"assessmentId":%d,"conditionalMetricId":%d,"dataSourceId":%d}
+                    """.formatted(metric.getId(), metric.getAssessmentId(), metric.getConditionalMetricId(), metric.getDataSourceId());
+
+            mvc.perform(put(API)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body)
+                    .with(httpBasic("biolab", "biolab")))
+               .andExpect(status().isConflict());
+        }
+
+        @Test
+        @DisplayName("DELETE succeeds when assessment has no sessions")
+        void delete_succeeds_whenNoSessions() throws Exception {
+            AssessmentMetric metric = factory.createAssessmentMetric();
+
+            mvc.perform(delete(API + "/" + metric.getId())
+                    .with(httpBasic("biolab", "biolab")))
+               .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    @DisplayName("counter updates")
+    class CounterUpdateTests {
+
+        @Test
+        @DisplayName("sessionCount increments when SessionMetric is created")
+        void sessionCount_increments_onSessionMetricCreate() throws Exception {
+            AssessmentMetric metric = factory.createAssessmentMetric();
+            Session session = factory.createSessionForAssessment(metric.getAssessmentId());
+
+            String smBody = """
+                    {"sessionId":%d,"conditionalMetricId":%d}
+                    """.formatted(session.getId(), metric.getConditionalMetricId());
+
+            mvc.perform(post("/api/v1/sessionMetrics")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(smBody)
+                    .with(httpBasic("biolab", "biolab")))
+               .andExpect(status().isOk());
+
+            mvc.perform(get(API + "/" + metric.getId())
+                    .with(httpBasic("biolab", "biolab")))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.sessionCount").value(1));
+        }
+
+        @Test
+        @DisplayName("repCount increments when RepMetric is created")
+        void repCount_increments_onRepMetricCreate() throws Exception {
+            AssessmentMetric metric = factory.createAssessmentMetric();
+            Rep rep = factory.createRepForAssessment(metric.getAssessmentId());
+
+            String rmBody = """
+                    {"repId":%d,"conditionalMetricId":%d}
+                    """.formatted(rep.getId(), metric.getConditionalMetricId());
+
+            mvc.perform(post("/api/v1/repMetrics")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(rmBody)
+                    .with(httpBasic("biolab", "biolab")))
+               .andExpect(status().isOk());
+
+            mvc.perform(get(API + "/" + metric.getId())
+                    .with(httpBasic("biolab", "biolab")))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.repCount").value(1));
         }
     }
 }

--- a/src/test/java/com/biolab/launchpad/internal/web/controller/EntityFactory.java
+++ b/src/test/java/com/biolab/launchpad/internal/web/controller/EntityFactory.java
@@ -330,6 +330,50 @@ public class EntityFactory {
         );
     }
 
+    public AssessmentMetric createAssessmentMetric() {
+        Assessment assessment = createAssessment();
+        ConditionalMetric cm  = createConditionalMetric();
+        DataSource dataSource = createDataSource(cm.getMetricId());
+        return assessmentMetricRepository.save(
+                AssessmentMetric.builder()
+                        .assessmentId(assessment.getId())
+                        .conditionalMetricId(cm.getId())
+                        .dataSourceId(dataSource.getId())
+                        .build()
+        );
+    }
+
+    public AssessmentMetric createAssessmentMetricForAssessment(Integer assessmentId) {
+        ConditionalMetric cm  = createConditionalMetric();
+        DataSource dataSource = createDataSource(cm.getMetricId());
+        return assessmentMetricRepository.save(
+                AssessmentMetric.builder()
+                        .assessmentId(assessmentId)
+                        .conditionalMetricId(cm.getId())
+                        .dataSourceId(dataSource.getId())
+                        .build()
+        );
+    }
+
+    public Session createSessionForAssessment(Integer assessmentId) {
+        return sessionRepository.save(
+                Session.builder()
+                        .assessmentId(assessmentId)
+                        .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 1)))
+                        .build()
+        );
+    }
+
+    public Rep createRepForAssessment(Integer assessmentId) {
+        Session session = createSessionForAssessment(assessmentId);
+        return repRepository.save(
+                Rep.builder()
+                        .sessionId(session.getId())
+                        .startTime(Timestamp.valueOf(LocalDateTime.of(2025, 10, 2, 14, 45, 1)))
+                        .build()
+        );
+    }
+
     public Condition createCondition(String name) {
         SportDictionary sportDictionary = createSportDictionary("AutoSport");
         return conditionRepository.save(

--- a/src/test/java/com/biolab/launchpad/internal/web/controller/SessionControllerIntegrationTest.java
+++ b/src/test/java/com/biolab/launchpad/internal/web/controller/SessionControllerIntegrationTest.java
@@ -49,7 +49,8 @@ class SessionControllerIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        assessment   = factory.createAssessment();
+        assessment = factory.createAssessment();
+        factory.createAssessmentMetricForAssessment(assessment.getId());
     }
 
     @AfterEach
@@ -388,6 +389,41 @@ class SessionControllerIntegrationTest {
             JsonNode actualNode   = objectMapper.readTree(jsonResponse);
 
             assertEquals(expectedNode, actualNode);
+        }
+    }
+
+    @Nested
+    @DisplayName("zero-metrics guard")
+    class ZeroMetricsGuardTests {
+
+        @Test
+        @DisplayName("POST returns 400 when assessment has no metrics")
+        void create_returns400_whenAssessmentHasNoMetrics() throws Exception {
+            Assessment emptyAssessment = factory.createAssessment();
+
+            String body = """
+                    {"assessmentId":%d,"startTime":"2025-10-02T14:45:01.000+00:00"}
+                    """.formatted(emptyAssessment.getId());
+
+            mvc.perform(post(API)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body)
+                    .with(httpBasic("biolab", "biolab")))
+               .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("POST succeeds when assessment has at least one metric")
+        void create_succeeds_whenAssessmentHasMetrics() throws Exception {
+            String body = """
+                    {"assessmentId":%d,"startTime":"2025-10-02T14:45:01.000+00:00"}
+                    """.formatted(assessment.getId());
+
+            mvc.perform(post(API)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body)
+                    .with(httpBasic("biolab", "biolab")))
+               .andExpect(status().isOk());
         }
     }
 


### PR DESCRIPTION
## Summary
- Block DELETE and PUT on `AssessmentMetric` (409) when assessment already has sessions
- Block `Session` create (400) when assessment has zero metrics
- Add `session_count` / `rep_count` columns to `assessment_metric` table; increment them when `SessionMetric` / `RepMetric` are created
- `AssessmentService.create()` auto-copies all `TemplateMetric` rows into `AssessmentMetric` when an assessment is created from a template

## Test Plan
- [ ] `AssessmentMetricControllerIntegrationTest` — lock guard tests (DELETE/PUT → 409 with sessions, DELETE → 200 without)
- [ ] `AssessmentMetricControllerIntegrationTest` — counter update tests (`sessionCount` increments on SessionMetric create, `repCount` on RepMetric create)
- [ ] `SessionControllerIntegrationTest` — zero-metrics guard (POST → 400 with no metrics, POST → 200 with metrics)
- [ ] Unit tests for `AssessmentMetricService`, `SessionService`, `SessionMetricService`, `RepMetricService`
- [ ] Full suite: `./gradlew test` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)